### PR TITLE
Custom post types don't work for bbPress Topics

### DIFF
--- a/elements/sidebars.php
+++ b/elements/sidebars.php
@@ -520,7 +520,7 @@ function memberlite_elements_get_widget_areas( $widget_areas ) {
 
 	//special case for bbpress search results page
 	if( empty( $memberlite_custom_sidebar ) && function_exists( 'is_bbpress' ) && is_bbpress() ) {
-		$widget_areas = array( memberlite_elements_get_default_sidebar_by_post_type( 'forum' ) );
+		$widget_areas = array( memberlite_elements_get_default_sidebar_by_post_type(get_post_type()));
 	}
 
 	//if no custom sidebar for this specific post and we're on a blog page, check if the blog page has one to inherit


### PR DESCRIPTION
If the post type is bbpress "topic" then this function overwrites widget areas with the "forum" type. This meant that Custom sidebar did not work correctly with Custom Post types.

I changed the hardcoded "forum" string with get_post_type() in memberlite_elements_get_widget_areas();