### PR TITLE
Adding filter so themes can remove elements they don't need to offer/support.

### DIFF
--- a/memberlite-elements.php
+++ b/memberlite-elements.php
@@ -25,9 +25,21 @@ function memberlite_elements_load() {
 	} else {
 		// We're Gucci
 		require_once( MEMBERLITE_ELEMENTS_DIR . "/elements/functions.php" );
-		require_once( MEMBERLITE_ELEMENTS_DIR . "/elements/landing_page.php" );
-		require_once( MEMBERLITE_ELEMENTS_DIR . "/elements/page_banners.php" );
-		require_once( MEMBERLITE_ELEMENTS_DIR . "/elements/sidebars.php" );
+
+		/**
+		 * Filter to allow themes to remove elements loaded 
+		 *
+		 */
+		$memberlite_elements_supported_elements = apply_filters( 'memberlite_elements_supported_elements', array( 'landing_page', 'page_banners', 'sidebars' ) );
+		if ( in_array( 'landing_page', $memberlite_elements_supported_elements ) ) {
+			require_once( MEMBERLITE_ELEMENTS_DIR . '/elements/landing_page.php' );
+		}
+		if ( in_array( 'page_banners', $memberlite_elements_supported_elements ) ) {
+			require_once( MEMBERLITE_ELEMENTS_DIR . '/elements/page_banners.php' );
+		}
+		if ( in_array( 'sidebars', $memberlite_elements_supported_elements ) ) {
+			require_once( MEMBERLITE_ELEMENTS_DIR . '/elements/sidebars.php' );
+		}
 	}
 }
 add_action( 'after_setup_theme', 'memberlite_elements_load', 1 );


### PR DESCRIPTION
Added new filter `memberlite_elements_supported_elements`. This will be used initially by the Memberlite Words theme to remove the sidebars and banners elements. 