### PR TITLE
Fix for themes using pre-Memberlite v4.5.4 where filter had two param…

### DIFF
--- a/elements/page_banners.php
+++ b/elements/page_banners.php
@@ -585,7 +585,7 @@ add_filter( 'memberlite_get_banner_image', 'memberlite_elements_get_banner_image
 /**
  * Filter to get the banner image src from MultiPostThumbnails if it exists
  */
-function memberlite_elements_banner_image_src( $memberlite_banner_image_src, $size, $post_id ) {
+function memberlite_elements_banner_image_src( $memberlite_banner_image_src, $size, $post_id = null ) {
 	if ( class_exists( 'MultiPostThumbnails') && ! empty( $post_id ) ) {
 		$post_type = get_post_type( $post_id );
 		if ( ! empty( $post_type ) ) {


### PR DESCRIPTION
…eters

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/memberlite-elements/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite-elements/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix for sites that may upgrade this plugin with an older version of Memberlite. In that version, the `memberlite_banner_image_src` filter had two paramters.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed case where sites using pre-v4.5.4 of Memberlite would get a fatal error on update.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.